### PR TITLE
turn str[]-> str in path argument of import view component to be compatible with react router 6

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -5,7 +5,7 @@ import { importEndpointConfig } from "./endpoints/import";
 import type { PluginTypes } from "./types";
 import { extendWebpackConfig } from "./webpack";
 import { ImportForm } from "./components/import/ImportForm";
-import { importView } from "./view/importView";
+import { importViews } from "./view/importView";
 import ImportList from "./components/import";
 
 type PluginType = (pluginOptions?: PluginTypes) => Plugin;
@@ -34,7 +34,7 @@ export const importExportPlugin: PluginType = (pluginOptions) => {
         views: {
           ...(config.admin?.components?.views || {}),
           // Add additional admin views here
-          Import: importView(config, pluginOptions),
+          ...importViews(config, pluginOptions),
         },
       },
     };

--- a/src/view/importView.ts
+++ b/src/view/importView.ts
@@ -9,23 +9,21 @@ export const importViews: (config: Config, pluginOptions?: PluginTypes) => admin
   pluginOptions,
 ) => {
   let importViews: adminViews = {};
-  if (!pluginOptions || !pluginOptions?.excludeCollections)
-    return {
-      Import: {
-        Component: ViewWrapper,
-        path: "/collections/:slug/import",
-      },
+  let paths: string[] = [];
+  if (!pluginOptions || !pluginOptions?.excludeCollections) {
+    paths.push("/collections/:slug/import");
+  } else {
+    paths = config
+      .collections!.filter(
+        (collection) => !pluginOptions.excludeCollections?.includes(collection.slug),
+      )
+      .map((collection) => `/collections/:${collection.slug}/import`);
+  }
+  paths.forEach((path) => {
+    importViews[`Import${path}`] = {
+      Component: ViewWrapper,
+      path,
     };
-  config
-    .collections!.filter(
-      (collection) => !pluginOptions.excludeCollections?.includes(collection.slug),
-    )
-    .forEach((collection) => {
-      importViews[`Import${collection.slug}`] = {
-        Component: ViewWrapper,
-        path: `/collections/:${collection.slug}/import`,
-      };
-    });
-
+  });
   return importViews;
 };

--- a/src/view/importView.ts
+++ b/src/view/importView.ts
@@ -2,20 +2,30 @@ import { AdminView, Config } from "payload/config";
 import ViewWrapper from "./ViewWrapper";
 import { PluginTypes } from "../types";
 
-//@ts-ignore -- path should be string not string[] but it is accepted as in ReactRouterDocs
-export const importView: (config: Config, pluginOptions?: PluginTypes) => AdminView = (
+type adminViews = { [key: string]: AdminView };
+
+export const importViews: (config: Config, pluginOptions?: PluginTypes) => adminViews = (
   config,
   pluginOptions,
 ) => {
+  let importViews: adminViews = {};
   if (!pluginOptions || !pluginOptions?.excludeCollections)
-    return { Component: ViewWrapper, path: "/collections/:slug/import" };
+    return {
+      Import: {
+        Component: ViewWrapper,
+        path: "/collections/:slug/import",
+      },
+    };
+  config
+    .collections!.filter(
+      (collection) => !pluginOptions.excludeCollections?.includes(collection.slug),
+    )
+    .forEach((collection) => {
+      importViews[`Import${collection.slug}`] = {
+        Component: ViewWrapper,
+        path: `/collections/:${collection.slug}/import`,
+      };
+    });
 
-  return {
-    Component: ViewWrapper,
-    path: config
-      .collections!.filter(
-        (collection) => !pluginOptions.excludeCollections?.includes(collection.slug),
-      )
-      .map((collection) => `/collections/:${collection.slug}/import`),
-  };
+  return importViews;
 };


### PR DESCRIPTION
- **turn str[]-> str in path argument of import view component**
Since React Router 6, path has to be a string.
See here: https://reactrouter.com/en/main/route/route
And here: https://stackoverflow.com/questions/69921188/react-router-dom-v6-pass-array-to-path
